### PR TITLE
Qtanh

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,8 +63,7 @@ eval_env.observation_space.seed(config['seed'])
 torch.manual_seed(config['seed'])
 np.random.seed(config['seed'])
 random.seed(config['seed'])
-#env.seed(config['seed'])
-#env.action_space.np_random.seed(config['seed'])
+
 if torch.cuda.is_available():
     torch.cuda.manual_seed(config['seed'])
     torch.cuda.manual_seed_all(config['seed'])
@@ -97,7 +96,7 @@ for i_episode in itertools.count(1):
     episode_steps = 0
     done = False
     
-    reset_result = env.reset(seed = 42 + total_numsteps)
+    reset_result = env.reset()
     if isinstance(reset_result, tuple):
         state, _ = reset_result  
     else:
@@ -105,11 +104,6 @@ for i_episode in itertools.count(1):
 
     acc_log_alpha = 0.
     while not done:
-        
-        torch.manual_seed(config['seed'])
-        np.random.seed(config['seed'])
-        random.seed(config['seed'])
-        
         if total_numsteps > config['num_steps']:
             break
         if config['start_steps'] > total_numsteps:

--- a/main.py
+++ b/main.py
@@ -71,7 +71,7 @@ if torch.cuda.is_available():
 torch.backends.cudnn.deterministic = True
 torch.backends.cudnn.benchmark = False
 
-agent = SAC(env.observation_space.shape[0], env.action_space, config, torch.tensor(config['alpha']))
+agent = SAC(env.observation_space.shape[0], env.action_space, config, config['alpha'])
 
 memory = ReplayMemory(config['replay_size'], config['seed'])
 

--- a/model.py
+++ b/model.py
@@ -3,49 +3,17 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributions import Normal
 
-LOG_SIG_MAX = 2
-LOG_SIG_MIN = -20
+LOG_STD_MAX = 2
+LOG_STD_MIN = -5
 epsilon = 1e-6
-
-# Initialize Policy weights
-def weights_init_(m):
-    if isinstance(m, nn.Linear):
-        torch.nn.init.xavier_uniform_(m.weight, gain=1)
-        torch.nn.init.constant_(m.bias, 0)
-
-
-class ValueNetwork(nn.Module):
-    def __init__(self, num_inputs, hidden_dim):
-        super(ValueNetwork, self).__init__()
-
-        self.linear1 = nn.Linear(num_inputs, hidden_dim)
-        self.linear2 = nn.Linear(hidden_dim, hidden_dim)
-        self.linear3 = nn.Linear(hidden_dim, 1)
-
-        self.apply(weights_init_)
-
-    def forward(self, state):
-        x = F.relu(self.linear1(state))
-        x = F.relu(self.linear2(x))
-        x = self.linear3(x)
-        return x
-
 
 class QNetwork(nn.Module):
     def __init__(self, num_inputs, num_actions, hidden_dim):
         super(QNetwork, self).__init__()
 
-        # Q1 architecture
         self.linear1 = nn.Linear(num_inputs + num_actions, hidden_dim)
         self.linear2 = nn.Linear(hidden_dim, hidden_dim)
         self.linear3 = nn.Linear(hidden_dim, 1)
-
-        # Q2 architecture
-        self.linear4 = nn.Linear(num_inputs + num_actions, hidden_dim)
-        self.linear5 = nn.Linear(hidden_dim, hidden_dim)
-        self.linear6 = nn.Linear(hidden_dim, 1)
-
-        self.apply(weights_init_)
 
     def forward(self, state, action):
         xu = torch.cat([state, action], 1)
@@ -54,11 +22,7 @@ class QNetwork(nn.Module):
         x1 = F.relu(self.linear2(x1))
         x1 = self.linear3(x1)
 
-        x2 = F.relu(self.linear4(xu))
-        x2 = F.relu(self.linear5(x2))
-        x2 = self.linear6(x2)
-
-        return x1, x2
+        return x1
 
 
 class GaussianPolicy(nn.Module):
@@ -70,25 +34,30 @@ class GaussianPolicy(nn.Module):
 
         self.mean_linear = nn.Linear(hidden_dim, num_actions)
         self.log_std_linear = nn.Linear(hidden_dim, num_actions)
-
-        self.apply(weights_init_)
-
         # action rescaling
-        if action_space is None:
-            self.action_scale = torch.tensor(1.)
-            self.action_bias = torch.tensor(0.)
-        else:
-            self.action_scale = torch.FloatTensor(
-                (action_space.high - action_space.low) / 2.)
-            self.action_bias = torch.FloatTensor(
-                (action_space.high + action_space.low) / 2.)
+        self.register_buffer(
+            "action_scale",
+            torch.tensor(
+                (action_space.high - action_space.low) / 2.0,
+                dtype=torch.float32,
+            ),
+        )
+        self.register_buffer(
+            "action_bias",
+            torch.tensor(
+                (action_space.high + action_space.low) / 2.0,
+                dtype=torch.float32,
+            ),
+        )
 
     def forward(self, state):
         x = F.relu(self.linear1(state))
         x = F.relu(self.linear2(x))
         mean = self.mean_linear(x)
         log_std = self.log_std_linear(x)
-        log_std = torch.clamp(log_std, min=LOG_SIG_MIN, max=LOG_SIG_MAX)
+        log_std = torch.tanh(log_std)
+        log_std = LOG_STD_MIN + 0.5 * (LOG_STD_MAX - LOG_STD_MIN) * (log_std + 1)  # From SpinUp / Denis Yarats
+        
         return mean, log_std
 
     def sample(self, state):
@@ -104,9 +73,3 @@ class GaussianPolicy(nn.Module):
         log_prob = log_prob.sum(1, keepdim=True)
         mean = torch.tanh(mean) * self.action_scale + self.action_bias
         return action, log_prob, mean
-
-    def to(self, device):
-        self.action_scale = self.action_scale.to(device)
-        self.action_bias = self.action_bias.to(device)
-        return super(GaussianPolicy, self).to(device)
-

--- a/sac.py
+++ b/sac.py
@@ -100,7 +100,7 @@ class SAC(object):
             self.alpha_optim.step()
 
             self.alpha = self.log_alpha.exp().item()
-            alpha_tlogs = self.alpha.clone() # For TensorboardX logs
+            alpha_tlogs = self.alpha
         else:
             alpha_loss = torch.tensor(0.).to(self.device)
             alpha_tlogs = torch.tensor(self.alpha) # For TensorboardX logs

--- a/sac.py
+++ b/sac.py
@@ -118,8 +118,10 @@ class SAC(object):
             save_path = './models/'
 
         actor_path = '{}actor_{}_{}'.format(save_path, env_name, suffix)
-        critic_path = "{}critic_{}_{}".format(save_path, env_name, suffix)
-        print('Saving models to {} and {}'.format(actor_path, critic_path))
+        q1_path = "{}q1_{}_{}".format(save_path, env_name, suffix)
+        q2_path = "{}q2_{}_{}".format(save_path, env_name, suffix)
+        print('Saving models to {} and {}'.format(actor_path, q1_path, q2_path))
         torch.save(self.policy.state_dict(), actor_path)
-        torch.save(self.critic.state_dict(), critic_path)
+        torch.save(self.qf1.state_dict(), q1_path)
+        torch.save(self.qf2.state_dict(), q2_path)
 

--- a/sac.py
+++ b/sac.py
@@ -18,17 +18,21 @@ class SAC(object):
 
         self.device = torch.device('cuda:' + str(config['cuda'])) if torch.cuda.is_available() and config['cuda'] >= 0 else torch.device('cpu')
 
-        self.critic = QNetwork(num_inputs, action_space.shape[0], config['hidden_size']).to(device=self.device)
-        self.critic_optim = Adam(self.critic.parameters(), lr=config['lr'])
+        self.qf1 = QNetwork(num_inputs, action_space.shape[0], config['hidden_size']).to(device=self.device)
+        self.qf2 = QNetwork(num_inputs, action_space.shape[0], config['hidden_size']).to(device=self.device)
+        self.critic_optim = Adam(list(self.qf1.parameters()) + list(self.qf2.parameters()), lr=config['lr'])
 
-        self.critic_target = QNetwork(num_inputs, action_space.shape[0], config['hidden_size']).to(self.device)
-        hard_update(self.critic_target, self.critic)
+        self.qf1_target = QNetwork(num_inputs, action_space.shape[0], config['hidden_size']).to(self.device)
+        self.qf2_target = QNetwork(num_inputs, action_space.shape[0], config['hidden_size']).to(self.device)
+        hard_update(self.qf1_target, self.qf1)
+        hard_update(self.qf2_target, self.qf2)
 
         if self.policy_type == "Gaussian":
             # Target Entropy = −dim(A) (e.g. , -6 for HalfCheetah-v2) as given in the paper
             if self.automatic_entropy_tuning == True:
                 self.target_entropy = -torch.prod(torch.Tensor(action_space.shape).to(self.device)).item()
                 self.log_alpha = torch.zeros(1, requires_grad=True, device=self.device)
+                self.alpha = self.log_alpha.exp().item()
                 self.alpha_optim = Adam([self.log_alpha], lr=config['lr'])
 
             self.policy = GaussianPolicy(num_inputs, action_space.shape[0], config['hidden_size'], action_space).to(self.device)
@@ -59,25 +63,25 @@ class SAC(object):
             #     policy_weights = torch.cat([p.data.view(-1) for p in self.policy.parameters()])
             #     print(policy_weights.mean().item())
             #     print(policy_weights.std().item())
-            qf1_next_target, qf2_next_target = self.critic_target(next_state_batch, next_state_action)
+            qf1_next_target = self.qf1_target(next_state_batch, next_state_action) 
+            qf2_next_target = self.qf2_target(next_state_batch, next_state_action)
             min_qf_next_target = torch.min(qf1_next_target, qf2_next_target) - self.alpha * next_state_log_pi
             next_q_value = reward_batch + mask_batch * self.gamma * (min_qf_next_target)
 
-        qf1, qf2 = self.critic(state_batch, action_batch)  # Two Q-functions to mitigate positive bias in the policy improvement step
+        qf1 = self.qf1(state_batch, action_batch)  
+        qf2 = self.qf2(state_batch, action_batch)  # Two Q-functions to mitigate positive bias in the policy improvement step
         qf1_loss = F.mse_loss(qf1, next_q_value) # JQ = 𝔼(st,at)~D[0.5(Q1(st,at) - r(st,at) - γ(𝔼st+1~p[V(st+1)]))^2]
         qf2_loss = F.mse_loss(qf2, next_q_value) # JQ = 𝔼(st,at)~D[0.5(Q1(st,at) - r(st,at) - γ(𝔼st+1~p[V(st+1)]))^2]
+        qf_loss = qf1_loss + qf2_loss
         
         self.critic_optim.zero_grad()
-        qf1_loss.backward()
-        self.critic_optim.step()
-
-        self.critic_optim.zero_grad()
-        qf2_loss.backward()
+        qf_loss.backward()
         self.critic_optim.step()
 
         pi, log_pi, _ = self.policy.sample(state_batch)
 
-        qf1_pi, qf2_pi = self.critic(state_batch, pi)
+        qf1_pi = self.qf1(state_batch, pi)
+        qf2_pi = self.qf2(state_batch, pi)
         min_qf_pi = torch.min(qf1_pi, qf2_pi)
 
         policy_loss = ((self.alpha * log_pi) - min_qf_pi).mean() # Jπ = 𝔼st∼D,εt∼N[α * logπ(f(εt;st)|st) − Q(st,f(εt;st))]
@@ -87,13 +91,15 @@ class SAC(object):
         self.policy_optim.step()
 
         if self.automatic_entropy_tuning:
-            alpha_loss = -(self.log_alpha * (log_pi + self.target_entropy).detach()).mean()
+            with torch.no_grad():
+                _, log_pi, _ = self.policy.sample(state_batch)
+            alpha_loss = -(self.log_alpha.exp() * (log_pi + self.target_entropy)).mean()
 
             self.alpha_optim.zero_grad()
             alpha_loss.backward()
             self.alpha_optim.step()
 
-            self.alpha = self.log_alpha.exp()
+            self.alpha = self.log_alpha.exp().item()
             alpha_tlogs = self.alpha.clone() # For TensorboardX logs
         else:
             alpha_loss = torch.tensor(0.).to(self.device)
@@ -101,7 +107,8 @@ class SAC(object):
 
 
         if updates % self.target_update_interval == 0:
-            soft_update(self.critic_target, self.critic, self.tau)
+            soft_update(self.qf1_target, self.qf1, self.tau)
+            soft_update(self.qf2_target, self.qf2, self.tau)
 
         return qf1_loss.item(), qf2_loss.item(), policy_loss.item(), alpha_loss.item(), alpha_tlogs.item()
 

--- a/sac.py
+++ b/sac.py
@@ -110,7 +110,7 @@ class SAC(object):
             soft_update(self.qf1_target, self.qf1, self.tau)
             soft_update(self.qf2_target, self.qf2, self.tau)
 
-        return qf1_loss.item(), qf2_loss.item(), policy_loss.item(), alpha_loss.item(), alpha_tlogs.item()
+        return qf1_loss.item(), qf2_loss.item(), policy_loss.item(), alpha_loss.item(), alpha_tlogs
 
     # Save model parameters    
     def save_model(self, save_path = None, env_name = None, suffix = None):

--- a/sac.py
+++ b/sac.py
@@ -103,7 +103,7 @@ class SAC(object):
             alpha_tlogs = self.alpha
         else:
             alpha_loss = torch.tensor(0.).to(self.device)
-            alpha_tlogs = torch.tensor(self.alpha) # For TensorboardX logs
+            alpha_tlogs = self.alpha # For TensorboardX logs
 
 
         if updates % self.target_update_interval == 0:

--- a/test.py
+++ b/test.py
@@ -227,14 +227,12 @@ if torch.cuda.is_available():
 torch.backends.cudnn.deterministic = True
 torch.backends.cudnn.benchmark = False
 
-torch.manual_seed(config['seed'])
 global_agent = {
     f'global': SAC(envs[0].observation_space.shape[0], envs[0].action_space, config, config['alpha'][0])
 }
 
 agents = {}
 for i in range(len(config['alpha'])):
-    torch.manual_seed(config['seed']) 
     agents[f'agent{i}'] = SAC(envs[i].observation_space.shape[0], envs[i].action_space, config, config['alpha'][i])
 
 memories = {

--- a/test.py
+++ b/test.py
@@ -281,7 +281,7 @@ test_rewards = {i: [] for i in range(len(agents))}
 test = {i: [] for i in range(len(agents))}
 
 for i in range(len(agents)):
-    agent_states[i], _ = envs[i].reset(seed = 42 + total_numstepss[i])
+    agent_states[i], _ = envs[i].reset()
     agent_dones[i] = False
     agent_episode_reward[i] = 0
     agent_episode_steps[i] = 0
@@ -300,14 +300,10 @@ while not all(total_numstepss[j] > config['num_steps'] for j in range(len(agents
         # print(f"agent{i}: total_numstepss {total_numstepss[i]}")
         if total_numstepss[i] > config['num_steps']:
             continue
-        
-        torch.manual_seed(config['seed'])
-        np.random.seed(config['seed'])
-        random.seed(config['seed'])
 
         if agent_dones[i]:
             # print(agent_episode_reward[i])
-            agent_states[i], _ = envs[i].reset(seed=42 + total_numstepss[i])
+            agent_states[i], _ = envs[i].reset()
             agent_dones[i] = False
             agent_episode_reward[i] = 0
             episode_stepss[i] = 0

--- a/test.py
+++ b/test.py
@@ -116,7 +116,7 @@ def run(i, agent, memory, env, eval_env, config, total_numsteps, episode_steps, 
             sync_gtoq_params(agent.policy, glo.policy)
             print(f"gtoq_agent{i}: total_numstepss {total_numsteps + 1}")
 
-        if (total_numsteps + 1) % 1000 == 0:
+        if (total_numsteps + 1) % 100 == 0:
             log_metrics(i, total_numsteps+1, agent, glo, memory, save_path)
 
     if config['start_steps'] > total_numsteps:

--- a/test.py
+++ b/test.py
@@ -116,7 +116,7 @@ def run(i, agent, memory, env, eval_env, config, total_numsteps, episode_steps, 
             sync_gtoq_params(agent.policy, glo.policy)
             print(f"gtoq_agent{i}: total_numstepss {total_numsteps + 1}")
 
-        if (total_numsteps + 1) % 100 == 0:
+        if (total_numsteps + 1) % 1000 == 0:
             log_metrics(i, total_numsteps+1, agent, glo, memory, save_path)
 
     if config['start_steps'] > total_numsteps:


### PR DESCRIPTION
CLRに近づけた実装に変更
・branch seedと同様の変更
・weights_init_,class ValueNetworkの削除
・class QNetworkを単一のqネットワークに変更
・self.register_bufferに変更
・[-5,2]に変更してtanhを線形写像したものに変更
・qf1,qf2に分離
・alpha_loss = -(self.log_alpha.exp() * (log_pi + self.target_entropy)).mean()でself.log_alpha.exp()はどっちかわからん